### PR TITLE
Fix #2267

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -25,6 +25,7 @@ Iztok Jeras
 James Hanlon
 James Hutchinson
 Jamey Hicks
+James Pallister
 Jan Van Winkel
 Jeremy Bennett
 John Coiner

--- a/src/V3Begin.cpp
+++ b/src/V3Begin.cpp
@@ -203,7 +203,7 @@ private:
     }
     virtual void visit(AstVarXRef* nodep) override {
         UINFO(9, "   VARXREF " << nodep << endl);
-        if (m_namedScope != "" && nodep->inlinedDots() == "") {
+        if (m_namedScope != "" && nodep->inlinedDots() == "" && !m_ftaskp) {
             nodep->inlinedDots(m_namedScope);
             UINFO(9, "    rescope to " << nodep << endl);
         }

--- a/test_regress/t/t_hier_task.pl
+++ b/test_regress/t/t_hier_task.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_hier_task.v
+++ b/test_regress/t/t_hier_task.v
@@ -1,0 +1,42 @@
+module mod_a;
+   mod_inner u_inner;
+   mod_a_mon u_a_mon;
+
+   initial begin
+      bit x;
+
+      u_inner.x = 1;
+      u_a_mon.y = 0;
+      u_a_mon.accessor;
+
+      if (u_a_mon.y != 1) begin
+         $write("%%Error: Incorrect value placed in submodule\n");
+         $stop;
+      end
+
+      u_inner.x = 0;
+      u_a_mon.accessor;
+
+      if (u_a_mon.y != 0) begin
+         $write("%%Error: Incorrect value placed in submodule\n");
+         $stop;
+      end
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule : mod_a
+
+module mod_inner;
+   logic x;
+endmodule : mod_inner
+
+module mod_a_mon;
+   bit y;
+   function void accessor;
+      begin : accessor_block
+         bit read_x = mod_a.u_inner.x;
+         y = read_x;
+      end
+   endfunction
+endmodule

--- a/test_regress/t/t_hier_task.v
+++ b/test_regress/t/t_hier_task.v
@@ -1,3 +1,9 @@
+// DESCRIPTION: Verilator: Test for issue #2267
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2020 by James Pallister.
+// SPDX-License-Identifier: CC0-1.0
+
 module mod_a;
    mod_inner u_inner;
    mod_a_mon u_a_mon;


### PR DESCRIPTION
Fix AstVarXRef rescoping issue #2267.

I believe the fix for #2176 to fix genblk naming for nested generate statement inadvertently causes hierarchical variable reference in a task to be assigned the wrong scope - this causes problems further down the line with LinkDot